### PR TITLE
Silence warning when .github/pull_request_template.md is missing

### DIFF
--- a/gh-prq
+++ b/gh-prq
@@ -417,7 +417,7 @@ main() {
     {
       echo
       echo
-      generate_pr_template "$base" "$head" "$(cat "$PR_TEMPLATE_FILE")"
+      generate_pr_template "$base" "$head" "$(cat "$PR_TEMPLATE_FILE" 2> /dev/null)"
     } > "$PR_FILE"
   else
     local prepend


### PR DESCRIPTION
Not all projects have this file. This change avoids a warning like:

```
cat: .github/pull_request_template.md: No such file or directory
https://github.com/owner/project/pull/1
```